### PR TITLE
Fix for issue #22

### DIFF
--- a/SieveTests/Entities/Post.cs
+++ b/SieveTests/Entities/Post.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations.Schema;
 using System.Linq;
 using System.Threading.Tasks;
 using Sieve.Attributes;
@@ -21,5 +22,9 @@ namespace SieveTests.Entities
 
         [Sieve(CanFilter = true, CanSort = true)]
         public DateTimeOffset DateCreated { get; set; } = DateTimeOffset.UtcNow;
+
+        [Sieve(CanFilter = true, CanSort = true)]
+        [Column(TypeName = "datetime")]
+        public DateTime DateLastViewed { get; set; } = DateTime.UtcNow;
     }
 }

--- a/SieveTests/Migrations/20180522013323_AddDateLastViewedColumn.Designer.cs
+++ b/SieveTests/Migrations/20180522013323_AddDateLastViewedColumn.Designer.cs
@@ -11,9 +11,10 @@ using System;
 namespace SieveTests.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20180522013323_AddDateLastViewedColumn")]
+    partial class AddDateLastViewedColumn
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/SieveTests/Migrations/20180522013323_AddDateLastViewedColumn.cs
+++ b/SieveTests/Migrations/20180522013323_AddDateLastViewedColumn.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using System;
+using System.Collections.Generic;
+
+namespace SieveTests.Migrations
+{
+    public partial class AddDateLastViewedColumn : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DateLastViewed",
+                table: "Posts",
+                type: "datetime",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DateLastViewed",
+                table: "Posts");
+        }
+    }
+}


### PR DESCRIPTION
This fixes issue #22, and adds a DateTime field to the integration test entity, along with DB migrations, to allow for testing using the DateTime datatype.

Although this issue specifically relates to the *datetime* datatype in SQL server, this fix should be beneficial elsewhere, as the LINQ filter expressions generated by SieveProcessor will more closely match those generated by Queryable.Where, which means that they are less likely to encounter issues with other ORMs and databases.