### PR TITLE
Allow Filters on different sources to share the same name

### DIFF
--- a/Sieve/Extensions/MethodInfoExtended.cs
+++ b/Sieve/Extensions/MethodInfoExtended.cs
@@ -1,0 +1,147 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+
+namespace Sieve.Extensions
+{
+    // The default GetMethod doesn't allow for generic methods which means
+    // custom filters for different sources can't share the same name.
+    // https://stackoverflow.com/questions/4035719/getmethod-for-generic-method
+    public static partial class MethodInfoExtended
+    {
+        /// <summary>
+        /// Search for a method by name and parameter types.  
+        /// Unlike GetMethod(), does 'loose' matching on generic
+        /// parameter types, and searches base interfaces.
+        /// </summary>
+        /// <exception cref="AmbiguousMatchException"/>
+        public static MethodInfo GetMethodExt(this Type thisType,
+                                                string name,
+                                                params Type[] parameterTypes)
+        {
+            return GetMethodExt(thisType,
+                                name,
+                                BindingFlags.Instance
+                                | BindingFlags.Static
+                                | BindingFlags.Public
+                                | BindingFlags.NonPublic
+                                | BindingFlags.FlattenHierarchy,
+                                parameterTypes);
+        }
+
+        /// <summary>
+        /// Search for a method by name, parameter types, and binding flags.  
+        /// Unlike GetMethod(), does 'loose' matching on generic
+        /// parameter types, and searches base interfaces.
+        /// </summary>
+        /// <exception cref="AmbiguousMatchException"/>
+        public static MethodInfo GetMethodExt(this Type thisType,
+                                                string name,
+                                                BindingFlags bindingFlags,
+                                                params Type[] parameterTypes)
+        {
+            MethodInfo matchingMethod = null;
+
+            // Check all methods with the specified name, including in base classes
+            GetMethodExt(ref matchingMethod, thisType, name, bindingFlags, parameterTypes);
+
+            // If we're searching an interface, we have to manually search base interfaces
+            if (matchingMethod == null && thisType.IsInterface)
+            {
+                foreach (Type interfaceType in thisType.GetInterfaces())
+                    GetMethodExt(ref matchingMethod,
+                                 interfaceType,
+                                 name,
+                                 bindingFlags,
+                                 parameterTypes);
+            }
+
+            return matchingMethod;
+        }
+
+        private static void GetMethodExt(ref MethodInfo matchingMethod,
+                                            Type type,
+                                            string name,
+                                            BindingFlags bindingFlags,
+                                            params Type[] parameterTypes)
+        {
+            // Check all methods with the specified name, including in base classes
+            foreach (MethodInfo methodInfo in type.GetMember(name,
+                                                             MemberTypes.Method,
+                                                             bindingFlags))
+            {
+                // Check that the parameter counts and types match, 
+                // with 'loose' matching on generic parameters
+                ParameterInfo[] parameterInfos = methodInfo.GetParameters();
+                if (parameterInfos.Length == parameterTypes.Length)
+                {
+                    int i = 0;
+                    for (; i < parameterInfos.Length; ++i)
+                    {
+                        if (!parameterInfos[i].ParameterType
+                                              .IsSimilarType(parameterTypes[i]))
+                            break;
+                    }
+                    if (i == parameterInfos.Length)
+                    {
+                        if (matchingMethod == null)
+                            matchingMethod = methodInfo;
+                        else
+                            throw new AmbiguousMatchException(
+                                   "More than one matching method found!");
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Special type used to match any generic parameter type in GetMethodExt().
+        /// </summary>
+        public class T
+        { }
+
+        /// <summary>
+        /// Determines if the two types are either identical, or are both generic 
+        /// parameters or generic types with generic parameters in the same
+        ///  locations (generic parameters match any other generic paramter,
+        /// but NOT concrete types).
+        /// </summary>
+        private static bool IsSimilarType(this Type thisType, Type type)
+        {
+            // Ignore any 'ref' types
+            if (thisType.IsByRef)
+                thisType = thisType.GetElementType();
+            if (type.IsByRef)
+                type = type.GetElementType();
+
+            // Handle array types
+            if (thisType.IsArray && type.IsArray)
+                return thisType.GetElementType().IsSimilarType(type.GetElementType());
+
+            // If the types are identical, or they're both generic parameters 
+            // or the special 'T' type, treat as a match
+            if (thisType == type || ((thisType.IsGenericParameter || thisType == typeof(T))
+                                 && (type.IsGenericParameter || type == typeof(T))))
+                return true;
+
+            // Handle any generic arguments
+            if (thisType.IsGenericType && type.IsGenericType)
+            {
+                Type[] thisArguments = thisType.GetGenericArguments();
+                Type[] arguments = type.GetGenericArguments();
+                if (thisArguments.Length == arguments.Length)
+                {
+                    for (int i = 0; i < thisArguments.Length; ++i)
+                    {
+                        if (!thisArguments[i].IsSimilarType(arguments[i]))
+                            return false;
+                    }
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/SieveUnitTests/Entities/Comment.cs
+++ b/SieveUnitTests/Entities/Comment.cs
@@ -1,8 +1,14 @@
-﻿namespace SieveUnitTests.Entities
+﻿using System;
+using Sieve.Attributes;
+
+namespace SieveUnitTests.Entities
 {
 	public class Comment
     {
         public int Id { get; set; }
+
+        [Sieve(CanFilter = true, CanSort = true)]
+        public DateTimeOffset DateCreated { get; set; } = DateTimeOffset.UtcNow;
 
         public string Text { get; set; }
     }

--- a/SieveUnitTests/Services/SieveCustomFilterMethods.cs
+++ b/SieveUnitTests/Services/SieveCustomFilterMethods.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using Sieve.Services;
 using SieveUnitTests.Entities;
 
@@ -9,6 +10,13 @@ namespace SieveUnitTests.Services
         public IQueryable<Post> IsNew(IQueryable<Post> source, string op, string value)
         {
             var result = source.Where(p => p.LikeCount < 100);
+
+            return result;
+        }
+
+        public IQueryable<Comment> IsNew(IQueryable<Comment> source, string op, string value)
+        {
+            var result = source.Where(c => c.DateCreated > DateTimeOffset.UtcNow.AddDays(-2));
 
             return result;
         }


### PR DESCRIPTION
While attempting to make a custom search filter that was shared across multiple models I found that once a specific filter name was used multiple times that filter would fail.

The `GetMethod` reflection call didn't take into account the actual type of the results.
It now searches specifically for the required method of the correct type and will search more generally if this fails to be able to throw the `IncompatibleMethodException`.

In the tests this allows `Posts` and `Comments` to both use the `IsNew` filter with their own implementations.