### PR TITLE
Added support for negated operators

### DIFF
--- a/Sieve/Models/FilterTerm.cs
+++ b/Sieve/Models/FilterTerm.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Linq;
-using System.Linq.Expressions;
 using System.Text.RegularExpressions;
 
 namespace Sieve.Models

--- a/Sieve/Models/FilterTerm.cs
+++ b/Sieve/Models/FilterTerm.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Linq.Expressions;
 using System.Text.RegularExpressions;
 
 namespace Sieve.Models
@@ -11,6 +12,10 @@ namespace Sieve.Models
         private const string EscapedPipePattern = @"(?<!($|[^\\])(\\\\)*?\\)\|";
 
         private static readonly string[] Operators = new string[] {
+                    "!@=*",
+                    "!_=*",
+                    "!@=",
+                    "!_=",
                     "==*",
                     "@=*",
                     "_=*",
@@ -34,7 +39,8 @@ namespace Sieve.Models
                 Values = filterSplits.Length > 1 ? Regex.Split(filterSplits[1], EscapedPipePattern).Select(t => t.Trim()).ToArray() : null;
                 Operator = Array.Find(Operators, o => value.Contains(o)) ?? "==";
                 OperatorParsed = GetOperatorParsed(Operator);
-                OperatorIsCaseInsensitive = Operator.Contains("*");
+                OperatorIsCaseInsensitive = Operator.EndsWith("*");
+                OperatorIsNegated = OperatorParsed != FilterOperator.NotEquals && Operator.StartsWith("!");
             }
 
         }
@@ -47,12 +53,11 @@ namespace Sieve.Models
 
         public string Operator { get; private set; }
 
-        private FilterOperator GetOperatorParsed(string Operator)
+        private FilterOperator GetOperatorParsed(string @operator)
         {
-            switch (Operator.Trim().ToLower())
+            switch (@operator.TrimEnd('*'))
             {
                 case "==":
-                case "==*":
                     return FilterOperator.Equals;
                 case "!=":
                     return FilterOperator.NotEquals;
@@ -65,10 +70,10 @@ namespace Sieve.Models
                 case "<=":
                     return FilterOperator.LessThanOrEqualTo;
                 case "@=":
-                case "@=*":
+                case "!@=":
                     return FilterOperator.Contains;
                 case "_=":
-                case "_=*":
+                case "!_=":
                     return FilterOperator.StartsWith;
                 default:
                     return FilterOperator.Equals;
@@ -76,6 +81,8 @@ namespace Sieve.Models
         }
 
         public bool OperatorIsCaseInsensitive { get; private set; }
+
+        public bool OperatorIsNegated { get; private set; }
 
         public bool Equals(FilterTerm other)
         {

--- a/Sieve/Models/IFilterTerm.cs
+++ b/Sieve/Models/IFilterTerm.cs
@@ -6,6 +6,7 @@
         string[] Names { get; }
         string Operator { get; }
         bool OperatorIsCaseInsensitive { get; }
+        bool OperatorIsNegated { get; }
         FilterOperator OperatorParsed { get; }
         string[] Values { get; }
     }

--- a/Sieve/Services/SieveProcessor.cs
+++ b/Sieve/Services/SieveProcessor.cs
@@ -203,13 +203,20 @@ namespace Sieve.Services
                                     .First(m => m.Name == "ToUpper" && m.GetParameters().Length == 0));
                             }
 
+                            var expression = GetExpression(filterTerm, filterValue, propertyValue);
+
+                            if (filterTerm.OperatorIsNegated)
+                            {
+                                expression = Expression.Not(expression);
+                            }
+
                             if (innerExpression == null)
                             {
-                                innerExpression = GetExpression(filterTerm, filterValue, propertyValue);
+                                innerExpression = expression;
                             }
                             else
                             {
-                                innerExpression = Expression.Or(innerExpression, GetExpression(filterTerm, filterValue, propertyValue));
+                                innerExpression = Expression.Or(innerExpression, expression);
                             }
                         }
                     }

--- a/SieveUnitTests/General.cs
+++ b/SieveUnitTests/General.cs
@@ -102,6 +102,19 @@ namespace SieveUnitTests
         }
 
         [TestMethod]
+        public void NotContainsWorks()
+        {
+            var model = new SieveModel()
+            {
+                Filters = "Title!@=D",
+            };
+
+            var result = _processor.Apply(model, _posts);
+
+            Assert.IsTrue(result.Count() == 3);
+        }
+
+        [TestMethod]
         public void CanFilterBools()
         {
             var model = new SieveModel()


### PR DESCRIPTION
This PR adds negated versions of some operators. I only added the negated versions for the `Contains` and `StartsWith` operators since those are the only ones for now with no equivalent (`Equals` has `NotEquals`, `GreaterThan` has `LessThanOrEqualTo`, etc.). I tried to do it in a sensible and extensible way for potential future operators.

This should fix #48.