### PR TITLE
Allowed configuring properties with identical name & type

### DIFF
--- a/SieveUnitTests/Entities/Comment.cs
+++ b/SieveUnitTests/Entities/Comment.cs
@@ -1,11 +1,16 @@
 ﻿using System;
 using Sieve.Attributes;
+using SieveUnitTests.ValueObjects;
 
 namespace SieveUnitTests.Entities
 {
 	public class Comment
     {
         public int Id { get; set; }
+
+        public Name AuthorFirstName { get; set; }
+
+        public Name AuthorLastName { get; set; }
 
         [Sieve(CanFilter = true, CanSort = true)]
         public DateTimeOffset DateCreated { get; set; } = DateTimeOffset.UtcNow;

--- a/SieveUnitTests/General.cs
+++ b/SieveUnitTests/General.cs
@@ -7,6 +7,7 @@ using Sieve.Models;
 using Sieve.Services;
 using SieveUnitTests.Entities;
 using SieveUnitTests.Services;
+using SieveUnitTests.ValueObjects;
 
 namespace SieveUnitTests
 {
@@ -63,17 +64,23 @@ namespace SieveUnitTests
                 new Comment() {
                     Id = 0,
                     DateCreated = DateTimeOffset.UtcNow.AddDays(-20),
-                    Text = "This is an old comment."
+                    Text = "This is an old comment.",
+                    AuthorFirstName = new Name("FirstName1"),
+                    AuthorLastName = new Name("LastName1")
                 },
                 new Comment() {
                     Id = 1,
                     DateCreated = DateTimeOffset.UtcNow.AddDays(-1),
-                    Text = "This is a fairly new comment."
+                    Text = "This is a fairly new comment.",
+                    AuthorFirstName = new Name("FirstName2"),
+                    AuthorLastName = new Name("LastName2")
                 },
                 new Comment() {
                     Id = 2,
                     DateCreated = DateTimeOffset.UtcNow,
-                    Text = "This is a brand new comment. ()"
+                    Text = "This is a brand new comment. ()",
+                    AuthorFirstName = new Name("FirstName3"),
+                    AuthorLastName = new Name("LastName3")
                 },
             }.AsQueryable();
         }
@@ -364,6 +371,21 @@ namespace SieveUnitTests
             Assert.AreEqual(posts[1].Id, 3);
             Assert.AreEqual(posts[2].Id, 2);
             Assert.AreEqual(posts[3].Id, 1);
+        }
+
+        [TestMethod]
+        public void NestedFilteringWithIdenticTypesWorks()
+        {
+            var model = new SieveModel()
+            {
+                Filters = "(firstName|lastName)@=*2",
+            };
+
+            var result = _processor.Apply(model, _comments);
+            Assert.AreEqual(1, result.Count());
+
+            var comment = result.First();
+            Assert.AreEqual(comment.Id, 1);
         }
     }
 }

--- a/SieveUnitTests/Services/ApplicationSieveProcessor.cs
+++ b/SieveUnitTests/Services/ApplicationSieveProcessor.cs
@@ -31,6 +31,14 @@ namespace SieveUnitTests.Services
             mapper.Property<Post>(p => p.OnlySortableViaFluentApi)
                 .CanSort();
 
+            mapper.Property<Comment>(c => c.AuthorFirstName.Value)
+                .CanFilter()
+                .HasName("firstName");
+
+            mapper.Property<Comment>(c => c.AuthorLastName.Value)
+                .CanFilter()
+                .HasName("lastName");
+
             return mapper;
         }
     }

--- a/SieveUnitTests/ValueObjects/Name.cs
+++ b/SieveUnitTests/ValueObjects/Name.cs
@@ -1,0 +1,43 @@
+﻿using System;
+
+namespace SieveUnitTests.ValueObjects
+{
+    public sealed class Name : IEquatable<Name>
+    {
+        public Name(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+            {
+                throw new InvalidOperationException("Invalid string!");
+            }
+
+            if (value.Length > 50)
+            {
+                throw new InvalidOperationException("String exceeds maximum name length!");
+            }
+
+            Value = value;
+        }
+
+        public string Value { get; private set; }
+
+        public bool Equals(Name other)
+        {
+            if (ReferenceEquals(null, other)) return false;
+            if (ReferenceEquals(this, other)) return true;
+            return string.Equals(Value, other.Value);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if (ReferenceEquals(null, obj)) return false;
+            if (ReferenceEquals(this, obj)) return true;
+            return obj is Name && Equals((Name) obj);
+        }
+
+        public override int GetHashCode()
+        {
+            return (Value != null ? Value.GetHashCode() : 0);
+        }
+    }
+}


### PR DESCRIPTION
Since sorting/filtering nested objects has been implemented, we are now able to do the following:

`mapper.Property<Entity>(e => e.Property1.Value).CanFilter().HasName("property1");
mapper.Property<Entity>(e => e.Property2.Value).CanFilter().HasName("property2");`

The actual implementation of the mapper uses dictionary, which allows one value per unique key. For the example given above, the mapper will overwrite the configuration for the Property1 with the configuration of the Property2. Hence trying to filter with the filter "(property1|property2)@=*a" fails by throwing an exception since "property1" name does not exist (it has been overwritten by property 2). 

This can be solved by changing the internal store of the mapper, using a data structure that would allow storing multiple values for the same key. I implemented it using a collection of key value pairs, but a lookup or something similar would also do it (I don't really know how a lookup approach would look like since it has no add/remove methods and you should recreate it for every new configuration).
It would be nice for Sieve to support this. I actually came across this problem after updating to the latest version of the package and testing the scenario that I talked about in my previous issue (see attached image for code)


![image](https://user-images.githubusercontent.com/19924311/52179204-06197500-27e0-11e9-8594-5a883b8d1032.png)
