### PR TITLE
fix: dont process when filterTerm.Values is null

### DIFF
--- a/Sieve/Services/SieveProcessor.cs
+++ b/Sieve/Services/SieveProcessor.cs
@@ -186,6 +186,8 @@ namespace Sieve.Services
                         {
                             propertyValue = Expression.PropertyOrField(propertyValue, part);
                         }
+                        
+                        if (filterTerm.Values == null) continue;
 
                         foreach (var filterTermValue in filterTerm.Values)
                         {


### PR DESCRIPTION
If the user passes in a filter param that is null, the processor will throw an exception and cancel processing. 