### PR TITLE
Added support for generic filter and sort methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,15 @@ public class SieveCustomSortMethods : ISieveCustomSortMethods
 
         return result; // Must return modified IQueryable<TEntity>
     }
+
+    public IQueryable<T> Oldest<T>(IQueryable<T> source, bool useThenBy, bool desc) where T : BaseEntity // Generic functions are allowed too
+    {
+        var result = useThenBy ?
+            ((IOrderedQueryable<T>)source).ThenByDescending(p => p.DateCreated) :
+            source.OrderByDescending(p => p.DateCreated);
+
+        return result;
+    }
 }
 ```
 And `SieveCustomFilterMethods`:
@@ -96,6 +105,12 @@ public class SieveCustomFilterMethods : ISieveCustomFilterMethods
                                         p.CommentCount < 5);
 
         return result; // Must return modified IQueryable<TEntity>
+    }
+
+    public IQueryable<T> Latest<T>(IQueryable<T> source, string op, string[] values) where T : BaseEntity // Generic functions are allowed too
+    {
+        var result = source.Where(c => c.DateCreated > DateTimeOffset.UtcNow.AddDays(-14));
+        return result;
     }
 }
 ```

--- a/Sieve/Services/SieveProcessor.cs
+++ b/Sieve/Services/SieveProcessor.cs
@@ -387,6 +387,28 @@ namespace Sieve.Services
                 _options.Value.CaseSensitive ? BindingFlags.Default : BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance,
                 typeof(IQueryable<TEntity>));
 
+
+            if (customMethod == null)
+            {
+                // Find generic methods `public IQueryable<T> Filter<T>(IQueryable<T> source, ...)`
+                var genericCustomMethod = parent?.GetType()
+                .GetMethodExt(name,
+                _options.Value.CaseSensitive ? BindingFlags.Default : BindingFlags.IgnoreCase | BindingFlags.Public | BindingFlags.Instance,
+                typeof(IQueryable<>));
+
+                if (genericCustomMethod != null &&
+                    genericCustomMethod.ReturnType.IsGenericType &&
+                    genericCustomMethod.ReturnType.GetGenericTypeDefinition() == typeof(IQueryable<>))
+                {
+                    var genericBaseType = genericCustomMethod.ReturnType.GenericTypeArguments[0];
+                    var constraints = genericBaseType.GetGenericParameterConstraints();
+                    if (constraints == null || constraints.Length == 0 || constraints.All((t) => t.IsAssignableFrom(typeof(TEntity))))
+                    {
+                        customMethod = genericCustomMethod.MakeGenericMethod(typeof(TEntity));
+                    }
+                }
+            }
+
             if (customMethod != null)
             {
                 try

--- a/SieveUnitTests/Entities/BaseEntity.cs
+++ b/SieveUnitTests/Entities/BaseEntity.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using Sieve.Attributes;
+
+namespace SieveUnitTests.Entities
+{
+	public class BaseEntity
+    {
+        public int Id { get; set; }
+
+        [Sieve(CanFilter = true, CanSort = true)]
+        public DateTimeOffset DateCreated { get; set; } = DateTimeOffset.UtcNow;
+    }
+}

--- a/SieveUnitTests/Entities/Comment.cs
+++ b/SieveUnitTests/Entities/Comment.cs
@@ -3,13 +3,8 @@ using Sieve.Attributes;
 
 namespace SieveUnitTests.Entities
 {
-	public class Comment
+	public class Comment : BaseEntity
     {
-        public int Id { get; set; }
-
-        [Sieve(CanFilter = true, CanSort = true)]
-        public DateTimeOffset DateCreated { get; set; } = DateTimeOffset.UtcNow;
-
         [Sieve(CanFilter = true)]
         public string Text { get; set; }
     }

--- a/SieveUnitTests/Entities/Post.cs
+++ b/SieveUnitTests/Entities/Post.cs
@@ -3,9 +3,8 @@ using Sieve.Attributes;
 
 namespace SieveUnitTests.Entities
 {
-	public class Post
+	public class Post : BaseEntity
     {
-        public int Id { get; set; }
 
         [Sieve(CanFilter = true, CanSort = true)]
         public string Title { get; set; } = Guid.NewGuid().ToString().Replace("-", string.Empty).Substring(0, 8);
@@ -15,9 +14,6 @@ namespace SieveUnitTests.Entities
 
         [Sieve(CanFilter = true, CanSort = true)]
         public int CommentCount { get; set; } = new Random().Next(0, 1000);
-
-        [Sieve(CanFilter = true, CanSort = true)]
-        public DateTimeOffset DateCreated { get; set; } = DateTimeOffset.UtcNow;
 
         [Sieve(CanFilter = true, CanSort = true)]
         public int? CategoryId { get; set; } = new Random().Next(0, 4);

--- a/SieveUnitTests/General.cs
+++ b/SieveUnitTests/General.cs
@@ -194,6 +194,20 @@ namespace SieveUnitTests
         }
 
         [TestMethod]
+        public void CustomGenericFiltersWork()
+        {
+            var model = new SieveModel()
+            {
+                Filters = "Latest",
+            };
+
+            var result = _processor.Apply(model, _comments);
+
+            Assert.IsFalse(result.Any(p => p.Id == 0));
+            Assert.IsTrue(result.Count() == 2);
+        }
+
+        [TestMethod]
         public void CustomFiltersWithOperatorsWork()
         {
             var model = new SieveModel()
@@ -270,6 +284,19 @@ namespace SieveUnitTests
             var result = _processor.Apply(model, _posts);
 
             Assert.IsFalse(result.First().Id == 0);
+        }
+
+        [TestMethod]
+        public void CustomGenericSortsWork()
+        {
+            var model = new SieveModel()
+            {
+                Sorts = "Oldest",
+            };
+
+            var result = _processor.Apply(model, _posts);
+
+            Assert.IsTrue(result.Last().Id == 0);
         }
 
         [TestMethod]

--- a/SieveUnitTests/Services/SieveCustomFilterMethods.cs
+++ b/SieveUnitTests/Services/SieveCustomFilterMethods.cs
@@ -32,5 +32,11 @@ namespace SieveUnitTests.Services
         {
             return source;
         }
+
+        public IQueryable<T> Latest<T>(IQueryable<T> source, string op, string[] values) where T : BaseEntity
+        {
+            var result = source.Where(c => c.DateCreated > DateTimeOffset.UtcNow.AddDays(-14));
+            return result;
+        }
     }
 }

--- a/SieveUnitTests/Services/SieveCustomSortMethods.cs
+++ b/SieveUnitTests/Services/SieveCustomSortMethods.cs
@@ -16,5 +16,14 @@ namespace SieveUnitTests.Services
 
             return result;
         }
+
+        public IQueryable<T> Oldest<T>(IQueryable<T> source, bool useThenBy, bool desc) where T : BaseEntity
+        {
+            var result = useThenBy ?
+                ((IOrderedQueryable<T>)source).ThenByDescending(p => p.DateCreated) :
+                source.OrderByDescending(p => p.DateCreated);
+
+            return result;
+        }
     }
 }


### PR DESCRIPTION
This change allows us to use generic filter and sort methods like this:

```cs
    public IQueryable<T> Latest<T>(IQueryable<T> source, string op, string[] values) where T : BaseEntity 
    {
        var result = source.Where(c => c.DateCreated > DateTimeOffset.UtcNow.AddDays(-14));
        return result;
    }
```