### PR TITLE
Let you choose the Culture used for TypeConversion in the processor

### DIFF
--- a/Sieve/Models/SieveOptions.cs
+++ b/Sieve/Models/SieveOptions.cs
@@ -9,5 +9,7 @@
         public int MaxPageSize { get; set; } = 0;
 
         public bool ThrowExceptions { get; set; } = false;
+
+        public string CultureNameOfTypeConversion { get; set; } = "en";
     }
 }

--- a/Sieve/Services/SieveProcessor.cs
+++ b/Sieve/Services/SieveProcessor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -169,6 +170,8 @@ namespace Sieve.Services
                 return result;
             }
 
+            var cultureInfoToUseForTypeConversion = new CultureInfo(_options.Value.CultureNameOfTypeConversion ?? "en");
+
             Expression outerExpression = null;
             var parameterExpression = Expression.Parameter(typeof(TEntity), "e");
             foreach (var filterTerm in model.GetFiltersParsed())
@@ -193,7 +196,7 @@ namespace Sieve.Services
                         {
 
                             dynamic constantVal = converter.CanConvertFrom(typeof(string))
-                                                      ? converter.ConvertFrom(filterTermValue)
+                                                      ? converter.ConvertFrom(null, cultureInfoToUseForTypeConversion, filterTermValue)
                                                       : Convert.ChangeType(filterTermValue, property.PropertyType);
 
                             Expression filterValue = GetClosureOverConstant(constantVal, property.PropertyType);


### PR DESCRIPTION
Hello,

It would be nice to be able to choose the culture used for type conversion in the processor.

I have an API which have french as the default culture and this feature would let me force "english" as the culture used in the processor : I would be able to use decimal not formatted in french (comma can't be used because the SieveModel already uses them to separate filters) but in english in the processor.