### PR TITLE
Added Desc/Asc sort feature with unit tests

### DIFF
--- a/Sieve/Models/SortTerm.cs
+++ b/Sieve/Models/SortTerm.cs
@@ -16,9 +16,34 @@ namespace Sieve.Models
             }
         }
 
-        public string Name => (_sort.StartsWith("-")) ? _sort.Substring(1) : _sort;
+        public string Name
+        {
+            get
+            {
+                if (_sort.StartsWith("-"))
+                {
+                    return _sort.Substring(1);
+                }
+                else if (_sort.EndsWith(" desc"))
+                {
+                    return _sort.Replace(" desc", "");
+                }
+                else if (_sort.EndsWith(" asc"))
+                {
+                    return _sort.Replace(" asc", "");
+                }
+                else
+                    return _sort;
+            }
+        }
 
-        public bool Descending => _sort.StartsWith("-");
+        public bool Descending
+        {
+            get
+            {
+                return _sort.StartsWith("-") || _sort.EndsWith(" desc");
+            }
+        }
 
         public bool Equals(SortTerm other)
         {

--- a/SieveUnitTests/General.cs
+++ b/SieveUnitTests/General.cs
@@ -163,6 +163,32 @@ namespace SieveUnitTests
         }
 
         [TestMethod]
+        public void CanSortBoolsWithDesc()
+        {
+            var model = new SieveModel()
+            {
+                Sorts = "IsDraft desc"
+            };
+
+            var result = _processor.Apply(model, _posts);
+
+            Assert.AreEqual(result.First().Id, 0);
+        }
+
+        [TestMethod]
+        public void CanSortBoolsWithAsc()
+        {
+            var model = new SieveModel()
+            {
+                Sorts = "IsDraft asc"
+            };
+
+            var result = _processor.Apply(model, _posts);
+
+            Assert.AreEqual(result.First().Id, 1);
+        }
+
+        [TestMethod]
         public void CanFilterNullableInts()
         {
             var model = new SieveModel()


### PR DESCRIPTION
Added the capability to not only use '-FIELD' and 'FIELD' for sorting, but also allowing consumers to use 'FIELD desc' or 'FIELD asc'

Unit tests were added to confirm continuity 