### PR TITLE
Fix issue with spaces after comma and or filters

### DIFF
--- a/Sieve/Models/SieveModel.cs
+++ b/Sieve/Models/SieveModel.cs
@@ -13,7 +13,7 @@ namespace Sieve.Models
         where TFilterTerm : IFilterTerm, new()
         where TSortTerm : ISortTerm, new()
     {
-        private const string EscapedCommaPattern = @"(?<!($|[^\\])(\\\\)*?\\),";
+        private const string EscapedCommaPattern = @"(?<!($|[^\\])(\\\\)*?\\),\s*";
 
         [DataMember]
         public string Filters { get; set; }

--- a/SieveUnitTests/General.cs
+++ b/SieveUnitTests/General.cs
@@ -353,6 +353,23 @@ namespace SieveUnitTests
         }
 
         [TestMethod]
+        public void CombinedAndOrWithSpaceFilteringWorks()
+        {
+            var model = new SieveModel()
+            {
+                Filters = "Title==D, (Title|LikeCount)==3",
+            };
+
+            var result = _processor.Apply(model, _posts);
+            var entry = result.FirstOrDefault();
+            var resultCount = result.Count();
+
+            Assert.IsNotNull(entry);
+            Assert.AreEqual(1, resultCount);
+            Assert.AreEqual(3, entry.Id);
+        }
+
+        [TestMethod]
         public void OrValueFilteringWorks()
         {
             var model = new SieveModel()


### PR DESCRIPTION
Combined filters separated with comma and a space resulted in an error. 
Example: 
Title==D, (Title|LikeCount)==3
Caused the error: "(Title not found"

Extended regex to allow whitespaces after the comma as documented.