### PR TITLE
Fix issue where the order of Filter expressions changed the result.

### DIFF
--- a/Sieve/Models/SieveModel.cs
+++ b/Sieve/Models/SieveModel.cs
@@ -44,10 +44,7 @@ namespace Sieve.Models
                         {
                             Filter = subfilters + filterOpAndVal
                         };
-                        if (!value.Any(f => f.Names.Any(n => filterTerm.Names.Any(n2 => n2 == n))))
-                        {
-                            value.Add(filterTerm);
-                        }
+                        value.Add(filterTerm);
                     }
                     else
                     {

--- a/SieveUnitTests/General.cs
+++ b/SieveUnitTests/General.cs
@@ -352,6 +352,24 @@ namespace SieveUnitTests
             Assert.AreEqual(3, entry.Id);
         }
 
+        [DataTestMethod]
+        [DataRow("CategoryId==1,(CategoryId|LikeCount)==50")]
+        [DataRow("(CategoryId|LikeCount)==50,CategoryId==1")]
+        public void CombinedAndOrFilterIndependentOfOrder(string filter)
+        {
+            var model = new SieveModel()
+            {
+                Filters = filter,
+            };
+
+            var result = _processor.Apply(model, _posts);
+            var entry = result.FirstOrDefault();
+            var resultCount = result.Count();
+
+            Assert.IsNotNull(entry);
+            Assert.AreEqual(1, resultCount);
+        }
+
         [TestMethod]
         public void OrValueFilteringWorks()
         {


### PR DESCRIPTION
The following filter criteria should result in the same output, but
does not:
"CategoryId==1,(CategoryId|LikeCount)==50"
"(CategoryId|LikeCount)==50,CategoryId==1"

Cause is an optimization which removes or statements if one term
was already added in another statement. This optimization causes
a wrong result.