### PR TITLE
Fix issue where sorting or filtering a collection fails on accesssing null members.

### DIFF
--- a/Sieve/Extensions/OrderByDynamic.cs
+++ b/Sieve/Extensions/OrderByDynamic.cs
@@ -1,36 +1,62 @@
 ﻿using System;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Reflection;
 
 namespace Sieve.Extensions
 {
     public static partial class LinqExtentions
     {
-        public static IQueryable<TEntity> OrderByDynamic<TEntity>(this IQueryable<TEntity> source, string fullPropertyName, PropertyInfo propertyInfo,
-                          bool desc, bool useThenBy)
+        public static IQueryable<TEntity> OrderByDynamic<TEntity>(
+            this IQueryable<TEntity> source,
+            string fullPropertyName,
+            bool desc,
+            bool useThenBy)
         {
-            string command = desc ?
-                (useThenBy ? "ThenByDescending" : "OrderByDescending") :
-                (useThenBy ? "ThenBy" : "OrderBy");
-            var type = typeof(TEntity);
-            var parameter = Expression.Parameter(type, "p");
+            var lambda = GenerateLambdaWithSafeMemberAccess<TEntity>(fullPropertyName);
 
-            dynamic propertyValue = parameter;
-            if (fullPropertyName.Contains("."))
+            var command = desc
+                ? (useThenBy ? "ThenByDescending" : "OrderByDescending")
+                : (useThenBy ? "ThenBy" : "OrderBy");
+
+            var resultExpression = Expression.Call(
+                typeof(Queryable),
+                command,
+                new Type[] { typeof(TEntity), lambda.ReturnType },
+                source.Expression,
+                Expression.Quote(lambda));
+
+            return source.Provider.CreateQuery<TEntity>(resultExpression);
+        }
+
+        private static Expression<Func<TEntity, object>> GenerateLambdaWithSafeMemberAccess<TEntity>(string fullPropertyName)
+        {
+            var parameter = Expression.Parameter(typeof(TEntity), "e");
+            Expression propertyValue = parameter;
+            Expression nullCheck = null;
+
+            foreach (var name in fullPropertyName.Split('.'))
             {
-                var parts = fullPropertyName.Split('.');
-                for (var i = 0; i < parts.Length - 1; i++)
+                propertyValue = Expression.PropertyOrField(propertyValue, name);
+
+                if (propertyValue.Type.IsNullable())
                 {
-                    propertyValue = Expression.PropertyOrField(propertyValue, parts[i]);
+                    nullCheck = GenerateOrderNullCheckExpression(propertyValue, nullCheck);
                 }
             }
 
-            var propertyAccess = Expression.MakeMemberAccess(propertyValue, propertyInfo);
-            var orderByExpression = Expression.Lambda(propertyAccess, parameter);
-            var resultExpression = Expression.Call(typeof(Queryable), command, new Type[] { type, propertyInfo.PropertyType },
-                                          source.Expression, Expression.Quote(orderByExpression));
-            return source.Provider.CreateQuery<TEntity>(resultExpression);
+            var expression = nullCheck == null
+                ? propertyValue
+                : Expression.Condition(nullCheck, Expression.Default(propertyValue.Type), propertyValue);
+
+            var converted = Expression.Convert(expression, typeof(object));
+            return Expression.Lambda<Func<TEntity, object>>(converted, parameter);
+        }
+
+        private static Expression GenerateOrderNullCheckExpression(Expression propertyValue, Expression nullCheckExpression)
+        {
+            return nullCheckExpression == null
+                ? Expression.Equal(propertyValue, Expression.Default(propertyValue.Type))
+                : Expression.OrElse(nullCheckExpression, Expression.Equal(propertyValue, Expression.Default(propertyValue.Type)));
         }
     }
 }

--- a/Sieve/Extensions/OrderByDynamic.cs
+++ b/Sieve/Extensions/OrderByDynamic.cs
@@ -4,7 +4,7 @@ using System.Linq.Expressions;
 
 namespace Sieve.Extensions
 {
-    public static partial class LinqExtentions
+    public static partial class LinqExtensions
     {
         public static IQueryable<TEntity> OrderByDynamic<TEntity>(
             this IQueryable<TEntity> source,

--- a/Sieve/Extensions/TypeExtensions.cs
+++ b/Sieve/Extensions/TypeExtensions.cs
@@ -2,7 +2,7 @@
 
 namespace Sieve.Extensions
 {
-    public static partial class TypeExtentions
+    public static partial class TypeExtensions
     {
         public static bool IsNullable(this Type type)
         {

--- a/Sieve/Extensions/TypeExtentions.cs
+++ b/Sieve/Extensions/TypeExtentions.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Sieve.Extensions
+{
+    public static partial class TypeExtentions
+    {
+        public static bool IsNullable(this Type type)
+        {
+            return !type.IsValueType || Nullable.GetUnderlyingType(type) != null;
+        }
+    }
+}

--- a/SieveUnitTests/General.cs
+++ b/SieveUnitTests/General.cs
@@ -31,7 +31,6 @@ namespace SieveUnitTests
                     LikeCount = 100,
                     IsDraft = true,
                     CategoryId = null,
-                    TopComment = new Comment { Id = 0, Text = "A1" },
                     FeaturedComment = new Comment { Id = 4, Text = "A2" }
                 },
                 new Post() {
@@ -57,7 +56,7 @@ namespace SieveUnitTests
                     LikeCount = 3,
                     IsDraft = true,
                     CategoryId = 2,
-                    TopComment = new Comment { Id = 1, Text = "D1" },
+                    TopComment = new Comment { Id = 1 },
                     FeaturedComment = new Comment { Id = 7, Text = "D2" }
                 },
             }.AsQueryable();
@@ -388,11 +387,10 @@ namespace SieveUnitTests
             };
 
             var result = _processor.Apply(model, _posts);
-            Assert.AreEqual(3, result.Count());
+            Assert.AreEqual(2, result.Count());
             var posts = result.ToList();
             Assert.IsTrue(posts[0].TopComment.Text.Contains("B"));
             Assert.IsTrue(posts[1].TopComment.Text.Contains("C"));
-            Assert.IsTrue(posts[2].TopComment.Text.Contains("D"));
         }
 
         [TestMethod]


### PR DESCRIPTION
Generated lamda's have been updated to include null checks.

Example for filtering:
before `e => e.TopComment.Text.Contains("A")`
after `e => e.TopComment != default(Comment) && e.TopComment.Text != default(String) && e.TopComment.Text.Contains("A")`

Example for sorting:
before `e => e.TopComment.Id`
after `e => e.TopComment == default(Comment) ? default(Int32) : e.TopComment.Id`

