### PR TITLE
OrderByDynamic is modified to be able to handle inherited members...

### DIFF
--- a/SieveUnitTests/Abstractions/Entity/IBaseEntity.cs
+++ b/SieveUnitTests/Abstractions/Entity/IBaseEntity.cs
@@ -1,0 +1,10 @@
+﻿using System;
+
+namespace SieveUnitTests.Abstractions.Entity
+{
+    public interface IBaseEntity
+    {
+        int Id { get; set; }
+        DateTimeOffset DateCreated { get; set; }
+    }
+}

--- a/SieveUnitTests/Abstractions/Entity/IComment.cs
+++ b/SieveUnitTests/Abstractions/Entity/IComment.cs
@@ -1,0 +1,7 @@
+﻿namespace SieveUnitTests.Abstractions.Entity
+{
+    public interface IComment: IBaseEntity
+    {
+        string Text { get; set; }
+    }
+}

--- a/SieveUnitTests/Abstractions/Entity/IPost.cs
+++ b/SieveUnitTests/Abstractions/Entity/IPost.cs
@@ -1,0 +1,24 @@
+﻿using Sieve.Attributes;
+using SieveUnitTests.Entities;
+
+namespace SieveUnitTests.Abstractions.Entity
+{
+    public interface IPost: IBaseEntity
+    {
+        [Sieve(CanFilter = true, CanSort = true)]
+        string Title { get; set; }
+        [Sieve(CanFilter = true, CanSort = true)]
+        int LikeCount { get; set; }
+        [Sieve(CanFilter = true, CanSort = true)]
+        int CommentCount { get; set; }
+        [Sieve(CanFilter = true, CanSort = true)]
+        int? CategoryId { get; set; }
+        [Sieve(CanFilter = true, CanSort = true)]
+        bool IsDraft { get; set; }
+        string ThisHasNoAttribute { get; set; }
+        string ThisHasNoAttributeButIsAccessible { get; set; }
+        int OnlySortableViaFluentApi { get; set; }
+        Comment TopComment { get; set; }
+        Comment FeaturedComment { get; set; }
+    }
+}

--- a/SieveUnitTests/Entities/BaseEntity.cs
+++ b/SieveUnitTests/Entities/BaseEntity.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using Sieve.Attributes;
+using SieveUnitTests.Abstractions.Entity;
 
 namespace SieveUnitTests.Entities
 {
-    public class BaseEntity
+    public class BaseEntity : IBaseEntity
     {
         public int Id { get; set; }
 

--- a/SieveUnitTests/Entities/Comment.cs
+++ b/SieveUnitTests/Entities/Comment.cs
@@ -1,8 +1,9 @@
 ﻿using Sieve.Attributes;
+using SieveUnitTests.Abstractions.Entity;
 
 namespace SieveUnitTests.Entities
 {
-    public class Comment : BaseEntity
+    public class Comment : BaseEntity, IComment
     {
         [Sieve(CanFilter = true)]
         public string Text { get; set; }

--- a/SieveUnitTests/Entities/Post.cs
+++ b/SieveUnitTests/Entities/Post.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using Sieve.Attributes;
+using SieveUnitTests.Abstractions.Entity;
 
 namespace SieveUnitTests.Entities
 {
-    public class Post : BaseEntity
+    public class Post : BaseEntity, IPost
     {
 
         [Sieve(CanFilter = true, CanSort = true)]

--- a/SieveUnitTests/GeneralWithInterfaces.cs
+++ b/SieveUnitTests/GeneralWithInterfaces.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Sieve.Exceptions;
 using Sieve.Models;
@@ -12,19 +13,19 @@ using SieveUnitTests.Services;
 namespace SieveUnitTests
 {
     [TestClass]
-    public class General
+    public class GeneralWithInterfaces
     {
         private readonly SieveProcessor _processor;
-        private readonly IQueryable<Post> _posts;
+        private readonly IQueryable<IPost> _posts;
         private readonly IQueryable<Comment> _comments;
 
-        public General()
+        public GeneralWithInterfaces()
         {
             _processor = new ApplicationSieveProcessor(new SieveOptionsAccessor(),
                 new SieveCustomSortMethods(),
                 new SieveCustomFilterMethods());
 
-            _posts = new List<Post>
+            _posts = new List<IPost>
             {
                 new Post() {
                     Id = 0,

--- a/SieveUnitTests/Services/ApplicationSieveProcessor.cs
+++ b/SieveUnitTests/Services/ApplicationSieveProcessor.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Options;
 using Sieve.Models;
 using Sieve.Services;
+using SieveUnitTests.Abstractions.Entity;
 using SieveUnitTests.Entities;
 
 namespace SieveUnitTests.Services
@@ -38,6 +39,39 @@ namespace SieveUnitTests.Services
             mapper.Property<Post>(p => p.FeaturedComment.Text)
                 .CanFilter()
                 .HasName("featc");
+
+            mapper
+                .Property<Post>(p => p.DateCreated)
+                .CanSort()
+                .HasName("CreateDate");
+
+            // interfaces
+            mapper.Property<IPost>(p => p.ThisHasNoAttributeButIsAccessible)
+                .CanSort()
+                .CanFilter()
+                .HasName("shortname");
+
+            mapper.Property<IPost>(p => p.TopComment.Text)
+                .CanFilter();
+
+            mapper.Property<IPost>(p => p.TopComment.Id)
+                .CanSort();
+
+            mapper.Property<IPost>(p => p.OnlySortableViaFluentApi)
+                .CanSort();
+
+            mapper.Property<IPost>(p => p.TopComment.Text)
+                .CanFilter()
+                .HasName("topc");
+
+            mapper.Property<IPost>(p => p.FeaturedComment.Text)
+                .CanFilter()
+                .HasName("featc");
+
+            mapper
+                .Property<IPost>(p => p.DateCreated)
+                .CanSort()
+                .HasName("CreateDate");
 
             return mapper;
         }

--- a/SieveUnitTests/Services/SieveCustomFilterMethods.cs
+++ b/SieveUnitTests/Services/SieveCustomFilterMethods.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using Sieve.Services;
+using SieveUnitTests.Abstractions.Entity;
 using SieveUnitTests.Entities;
 
 namespace SieveUnitTests.Services
@@ -37,6 +38,32 @@ namespace SieveUnitTests.Services
         {
             var result = source.Where(c => c.DateCreated > DateTimeOffset.UtcNow.AddDays(-14));
             return result;
+        }
+
+        public IQueryable<IPost> IsNew(IQueryable<IPost> source, string op, string[] values)
+        {
+            var result = source.Where(p => p.LikeCount < 100);
+
+            return result;
+        }
+
+        public IQueryable<IPost> HasInTitle(IQueryable<IPost> source, string op, string[] values)
+        {
+            var result = source.Where(p => p.Title.Contains(values[0]));
+
+            return result;
+        }
+
+        public IQueryable<IComment> IsNew(IQueryable<IComment> source, string op, string[] values)
+        {
+            var result = source.Where(c => c.DateCreated > DateTimeOffset.UtcNow.AddDays(-2));
+
+            return result;
+        }
+
+        public IQueryable<IComment> TestComment(IQueryable<IComment> source, string op, string[] values)
+        {
+            return source;
         }
     }
 }

--- a/SieveUnitTests/Services/SieveCustomSortMethods.cs
+++ b/SieveUnitTests/Services/SieveCustomSortMethods.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using Sieve.Services;
+using SieveUnitTests.Abstractions.Entity;
 using SieveUnitTests.Entities;
 
 namespace SieveUnitTests.Services
@@ -17,7 +18,18 @@ namespace SieveUnitTests.Services
             return result;
         }
 
-        public IQueryable<T> Oldest<T>(IQueryable<T> source, bool useThenBy, bool desc) where T : BaseEntity
+        public IQueryable<IPost> Popularity(IQueryable<IPost> source, bool useThenBy, bool desc)
+        {
+            var result = useThenBy ?
+                ((IOrderedQueryable<IPost>)source).ThenBy(p => p.LikeCount) :
+                source.OrderBy(p => p.LikeCount)
+                    .ThenBy(p => p.CommentCount)
+                    .ThenBy(p => p.DateCreated);
+
+            return result;
+        }
+
+        public IQueryable<T> Oldest<T>(IQueryable<T> source, bool useThenBy, bool desc) where T : IBaseEntity
         {
             var result = useThenBy ?
                 ((IOrderedQueryable<T>)source).ThenByDescending(p => p.DateCreated) :

--- a/SieveUnitTests/Services/SieveOptionsAccessor.cs
+++ b/SieveUnitTests/Services/SieveOptionsAccessor.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.Extensions.Options;
 using Sieve.Models;
 
-namespace SieveUnitTests
+namespace SieveUnitTests.Services
 {
     public class SieveOptionsAccessor : IOptions<SieveOptions>
     {


### PR DESCRIPTION
- OrderByDynamic is modified to be able to handle inherited members, such as interface members.
- SieveProcessor is modified to pass propertyInfo to OrderByDynamic to avoid reattainment of propertyInfo required in Expression.MakeMemberAccess.
- SieveProcessor is modified to be able to handle possible multiple incompatible customMethods via AggregateException.
- Corresponding interfaces are generated for entities with related inheritance.
- ApplicationSieveProcessor is modified to include interface members.
- SieveCustomFilterMethods and SieveCustomSortMethod are modified to include interface related custom method modifications.
Interface accessed unit tests are added.

closed #97 