### PR TITLE
[NonBreaking] Inheritance improvements

### DIFF
--- a/Sieve.Sample/appsettings.Development.json
+++ b/Sieve.Sample/appsettings.Development.json
@@ -1,6 +1,5 @@
 ﻿{
   "Logging": {
-    "IncludeScopes": false,
     "LogLevel": {
       "Default": "Debug",
       "System": "Information",

--- a/Sieve.Sample/appsettings.json
+++ b/Sieve.Sample/appsettings.json
@@ -7,7 +7,6 @@
     "DefaultPageSize": 10
   },
   "Logging": {
-    "IncludeScopes": false,
     "Debug": {
       "LogLevel": {
         "Default": "Warning"


### PR DESCRIPTION
SieveProcessor.Options made protected property
Mapper assignment in constructor is moved to a null-coalescing member pair (a field and a property)
"IncludeScopes" switch is removed from appSettings.{env}.json files

closes #108 
closes #109 