### PR TITLE
Modified ci-cd definition (on tag pushed)

### DIFF
--- a/.github/workflows/ci_publish.yml
+++ b/.github/workflows/ci_publish.yml
@@ -19,8 +19,9 @@ name: ci_publish
 on:
   push:
     branches:
-      - master
       - 'releases/*'
+    tags:
+      - 'v*'
 
 jobs:
   ubuntu-latest:

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -21,7 +21,8 @@ using static Nuke.Common.Tools.DotNet.DotNetTasks;
     InvokedTargets = new[] {nameof(Ci)},
     CacheKeyFiles = new string[0])]
 [GitHubActions("ci_publish", GitHubActionsImage.UbuntuLatest,
-    OnPushBranches = new[] {"master", "releases/*"},
+    OnPushBranches = new[] { "releases/*" },
+    OnPushTags = new[] { "v*" },
     AutoGenerate = true,
     InvokedTargets = new[] {nameof(CiPublish)},
     CacheKeyFiles = new string[0],
@@ -83,6 +84,7 @@ class Build : NukeBuild
     Target Package => _ => _
         .DependsOn(Test)
         .Executes(() =>
+        
         {
             DotNetPack(s => s
                 .SetProject(SieveProject)


### PR DESCRIPTION
Manually managed tags for lib versioned releases