### PR TITLE
Modular mapping configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,12 +260,77 @@ public class ApplicationSieveProcessor : SieveProcessor
 }
 ```
 
+
+
 Now you should inject the new class instead:
 ```C#
 services.AddScoped<ISieveProcessor, ApplicationSieveProcessor>();
 ```
-
 Find More on Sieve's Fluent API [here](https://github.com/Biarity/Sieve/issues/4#issuecomment-364629048).
+
+### Modular Fluent API configuration
+Adding all fluent mappings directly in the processor can become unwieldy on larger projects.
+It can also clash with vertical architectures.
+To enable functional grouping of mappings the `ISieveConfiguration` interface was created together with extensions to the default mapper.
+```C#
+public class SieveConfigurationForPost : ISieveConfiguration
+{
+    protected override SievePropertyMapper Configure(SievePropertyMapper mapper)
+    {
+        mapper.Property<Post>(p => p.Title)
+            .CanFilter()
+            .HasName("a_different_query_name_here");
+
+        mapper.Property<Post>(p => p.CommentCount)
+            .CanSort();
+
+        mapper.Property<Post>(p => p.DateCreated)
+            .CanSort()
+            .CanFilter()
+            .HasName("created_on");
+
+        return mapper;
+    }
+}
+```
+With the processor simplified to:
+```C#
+public class ApplicationSieveProcessor : SieveProcessor
+{
+    public ApplicationSieveProcessor(
+        IOptions<SieveOptions> options, 
+        ISieveCustomSortMethods customSortMethods, 
+        ISieveCustomFilterMethods customFilterMethods) 
+        : base(options, customSortMethods, customFilterMethods)
+    {
+    }
+
+    protected override SievePropertyMapper MapProperties(SievePropertyMapper mapper)
+    {
+        return mapper
+            .ApplyConfiguration<SieveConfigurationForPost>()
+            .ApplyConfiguration<SieveConfigurationForComment>();       
+    }
+}
+```
+There is also the option to scan and add all configurations for a given assembly
+```C#
+public class ApplicationSieveProcessor : SieveProcessor
+{
+    public ApplicationSieveProcessor(
+        IOptions<SieveOptions> options, 
+        ISieveCustomSortMethods customSortMethods, 
+        ISieveCustomFilterMethods customFilterMethods) 
+        : base(options, customSortMethods, customFilterMethods)
+    {
+    }
+
+    protected override SievePropertyMapper MapProperties(SievePropertyMapper mapper)
+    {
+        return mapper.ApplyConfigurationForAssembly(typeof(ApplicationSieveProcessor).Assembly);            
+    }
+}
+```
 
 ## Upgrading to v2.2.0
 

--- a/Sieve.Sample/Entities/SieveConfigurationForPost.cs
+++ b/Sieve.Sample/Entities/SieveConfigurationForPost.cs
@@ -1,0 +1,15 @@
+﻿using Sieve.Services;
+
+namespace Sieve.Sample.Entities
+{
+    public class SieveConfigurationForPost : ISieveConfiguration
+    {
+        public void Configure(SievePropertyMapper mapper)
+        {
+            mapper.Property<Post>(p => p.Title)
+                .CanSort()
+                .CanFilter()
+                .HasName("CustomTitleName");
+        }
+    }
+}

--- a/Sieve.Sample/Services/ApplicationSieveProcessor.cs
+++ b/Sieve.Sample/Services/ApplicationSieveProcessor.cs
@@ -13,10 +13,17 @@ namespace Sieve.Sample.Services
 
         protected override SievePropertyMapper MapProperties(SievePropertyMapper mapper)
         {
+            // Option 1: Map all properties centrally
             mapper.Property<Post>(p => p.Title)
                 .CanSort()
                 .CanFilter()
                 .HasName("CustomTitleName");
+
+            // Option 2: Manually apply functionally grouped mapping configurations
+            //mapper.ApplyConfiguration<SieveConfigurationForPost>();
+            
+            // Option 3: Scan and apply all configurations
+            //mapper.ApplyConfigurationsFromAssembly(typeof(ApplicationSieveProcessor).Assembly);
 
             return mapper;
         }

--- a/Sieve/Services/ISieveConfiguration.cs
+++ b/Sieve/Services/ISieveConfiguration.cs
@@ -1,0 +1,70 @@
+﻿#nullable enable
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace Sieve.Services
+{
+    /// <summary>
+    /// Use this interface to create SieveConfiguration (just like EntityTypeConfigurations are defined for EF)
+    /// </summary>
+    public interface ISieveConfiguration
+    {
+        /// <summary>
+        ///  Configures sieve property mappings.
+        /// </summary>
+        /// <param name="mapper"> The mapper used to configure the sieve properties on. </param>
+        void Configure(SievePropertyMapper mapper);
+    }
+
+    /// <summary>
+    /// Configuration extensions to the <see cref="SievePropertyMapper" />
+    /// </summary>
+    public static class SieveConfigurationExtensions
+    {
+        /// <summary>
+        ///     Applies configuration that is defined in an <see cref="ISieveConfiguration" /> instance.
+        /// </summary>
+        /// <param name="mapper"> The mapper to apply the configuration on. </param>
+        /// <typeparam name="T">The configuration to be applied. </typeparam>
+        /// <returns>
+        ///     The same <see cref="SievePropertyMapper" /> instance so that additional configuration calls can be chained.
+        /// </returns>
+        public static SievePropertyMapper ApplyConfiguration<T>(this SievePropertyMapper mapper) where T : ISieveConfiguration, new()
+        {
+            var configuration = new T();
+            configuration.Configure(mapper);
+            return mapper;
+        }
+
+        /// <summary>
+        ///     Applies configuration from all <see cref="ISieveConfiguration" />
+        ///     instances that are defined in provided assembly.
+        /// </summary>
+        /// <param name="mapper"> The mapper to apply the configuration on. </param>
+        /// <param name="assembly"> The assembly to scan. </param>
+        /// <returns>
+        ///     The same <see cref="SievePropertyMapper" /> instance so that additional configuration calls can be chained.
+        /// </returns>
+        public static SievePropertyMapper ApplyConfigurationsFromAssembly(this SievePropertyMapper mapper, Assembly assembly)
+        {
+            foreach (var type in assembly.GetTypes().Where(t => !t.IsAbstract && !t.IsGenericTypeDefinition))
+            {
+                // Only accept types that contain a parameterless constructor, are not abstract.
+                var noArgConstructor = type.GetConstructor(Type.EmptyTypes);
+                if (noArgConstructor is null)
+                {
+                    continue;
+                }
+
+                if (type.GetInterfaces().Any(t => t == typeof(ISieveConfiguration)))
+                {
+                    var configuration = (ISieveConfiguration)noArgConstructor.Invoke(new object?[] { });
+                    configuration.Configure(mapper);
+                }
+            }
+
+            return mapper;
+        }
+    }
+}

--- a/SieveUnitTests/Abstractions/Entity/SieveConfigurationForIPost.cs
+++ b/SieveUnitTests/Abstractions/Entity/SieveConfigurationForIPost.cs
@@ -1,0 +1,37 @@
+﻿using Sieve.Services;
+
+namespace SieveUnitTests.Abstractions.Entity
+{
+    public class SieveConfigurationForIPost : ISieveConfiguration
+    {
+        public void Configure(SievePropertyMapper mapper)
+        {
+            mapper.Property<IPost>(p => p.ThisHasNoAttributeButIsAccessible)
+                .CanSort()
+                .CanFilter()
+                .HasName("shortname");
+            
+            mapper.Property<IPost>(p => p.TopComment.Text)
+                .CanFilter();
+
+            mapper.Property<IPost>(p => p.TopComment.Id)
+                .CanSort();
+
+            mapper.Property<IPost>(p => p.OnlySortableViaFluentApi)
+                .CanSort();
+
+            mapper.Property<IPost>(p => p.TopComment.Text)
+                .CanFilter()
+                .HasName("topc");
+
+            mapper.Property<IPost>(p => p.FeaturedComment.Text)
+                .CanFilter()
+                .HasName("featc");
+
+            mapper
+                .Property<IPost>(p => p.DateCreated)
+                .CanSort()
+                .HasName("CreateDate");
+        }
+    }
+}

--- a/SieveUnitTests/Entities/SieveConfigurationForPost.cs
+++ b/SieveUnitTests/Entities/SieveConfigurationForPost.cs
@@ -1,0 +1,37 @@
+﻿using Sieve.Services;
+
+namespace SieveUnitTests.Entities
+{
+    public class SieveConfigurationForPost : ISieveConfiguration
+    {
+        public void Configure(SievePropertyMapper mapper)
+        {
+            mapper.Property<Post>(p => p.ThisHasNoAttributeButIsAccessible)
+                .CanSort()
+                .CanFilter()
+                .HasName("shortname");
+
+            mapper.Property<Post>(p => p.TopComment.Text)
+                .CanFilter();
+
+            mapper.Property<Post>(p => p.TopComment.Id)
+                .CanSort();
+
+            mapper.Property<Post>(p => p.OnlySortableViaFluentApi)
+                .CanSort();
+
+            mapper.Property<Post>(p => p.TopComment.Text)
+                .CanFilter()
+                .HasName("topc");
+
+            mapper.Property<Post>(p => p.FeaturedComment.Text)
+                .CanFilter()
+                .HasName("featc");
+
+            mapper
+                .Property<Post>(p => p.DateCreated)
+                .CanSort()
+                .HasName("CreateDate");
+        }
+    }
+}

--- a/SieveUnitTests/Mapper.cs
+++ b/SieveUnitTests/Mapper.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Sieve.Exceptions;
 using Sieve.Models;
+using Sieve.Services;
 using SieveUnitTests.Entities;
 using SieveUnitTests.Services;
 using Xunit;
@@ -10,15 +11,10 @@ namespace SieveUnitTests
 {
     public class Mapper
     {
-        private readonly ApplicationSieveProcessor _processor;
         private readonly IQueryable<Post> _posts;
 
         public Mapper()
         {
-            _processor = new ApplicationSieveProcessor(new SieveOptionsAccessor(),
-                new SieveCustomSortMethods(),
-                new SieveCustomFilterMethods());
-
             _posts = new List<Post>
             {
                 new Post
@@ -45,23 +41,49 @@ namespace SieveUnitTests
             }.AsQueryable();
         }
 
-        [Fact]
-        public void MapperWorks()
+        /// <summary>
+        /// Processors with the same mappings but configured via a different method.
+        /// </summary>
+        /// <returns></returns>
+        public static IEnumerable<object[]> GetProcessors()
+        {
+            yield return new object[] { 
+                new ApplicationSieveProcessor(
+                    new SieveOptionsAccessor(),
+                    new SieveCustomSortMethods(),
+                    new SieveCustomFilterMethods())};
+            yield return new object[] { 
+                new ModularConfigurationSieveProcessor(
+                    new SieveOptionsAccessor(),
+                    new SieveCustomSortMethods(),
+                    new SieveCustomFilterMethods())};
+            yield return new object[] { 
+                new ModularConfigurationWithScanSieveProcessor(
+                    new SieveOptionsAccessor(),
+                    new SieveCustomSortMethods(),
+                    new SieveCustomFilterMethods())};
+        }
+        
+        
+        [Theory]
+        [MemberData(nameof(GetProcessors))]
+        public void MapperWorks(ISieveProcessor processor)
         {
             var model = new SieveModel
             {
                 Filters = "shortname@=A",
             };
 
-            var result = _processor.Apply(model, _posts);
+            var result = processor.Apply(model, _posts);
 
             Assert.Equal("A", result.First().ThisHasNoAttributeButIsAccessible);
 
             Assert.True(result.Count() == 1);
         }
 
-        [Fact]
-        public void MapperSortOnlyWorks()
+        [Theory]
+        [MemberData(nameof(GetProcessors))]
+        public void MapperSortOnlyWorks(ISieveProcessor processor)
         {
             var model = new SieveModel
             {
@@ -69,9 +91,9 @@ namespace SieveUnitTests
                 Sorts = "OnlySortableViaFluentApi"
             };
 
-            var result = _processor.Apply(model, _posts, applyFiltering: false, applyPagination: false);
+            var result = processor.Apply(model, _posts, applyFiltering: false, applyPagination: false);
 
-            Assert.Throws<SieveMethodNotFoundException>(() => _processor.Apply(model, _posts));
+            Assert.Throws<SieveMethodNotFoundException>(() => processor.Apply(model, _posts));
 
             Assert.Equal(3, result.First().Id);
 

--- a/SieveUnitTests/Services/ModularConfigurationSieveProcessor.cs
+++ b/SieveUnitTests/Services/ModularConfigurationSieveProcessor.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.Extensions.Options;
+using Sieve.Models;
+using Sieve.Services;
+using SieveUnitTests.Abstractions.Entity;
+using SieveUnitTests.Entities;
+
+namespace SieveUnitTests.Services
+{
+    public class ModularConfigurationSieveProcessor : SieveProcessor
+    {
+        public ModularConfigurationSieveProcessor(
+            IOptions<SieveOptions> options,
+            ISieveCustomSortMethods customSortMethods,
+            ISieveCustomFilterMethods customFilterMethods)
+            : base(options, customSortMethods, customFilterMethods)
+        {
+        }
+
+        protected override SievePropertyMapper MapProperties(SievePropertyMapper mapper)
+        {
+            return mapper
+                .ApplyConfiguration<SieveConfigurationForPost>()
+                .ApplyConfiguration<SieveConfigurationForIPost>();
+        }
+    }
+}

--- a/SieveUnitTests/Services/ModularConfigurationWithScanSieveProcessor.cs
+++ b/SieveUnitTests/Services/ModularConfigurationWithScanSieveProcessor.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.Extensions.Options;
+using Sieve.Models;
+using Sieve.Services;
+
+namespace SieveUnitTests.Services
+{
+    public class ModularConfigurationWithScanSieveProcessor : SieveProcessor
+    {
+        public ModularConfigurationWithScanSieveProcessor(
+            IOptions<SieveOptions> options,
+            ISieveCustomSortMethods customSortMethods,
+            ISieveCustomFilterMethods customFilterMethods)
+            : base(options, customSortMethods, customFilterMethods)
+        {
+        }
+
+        protected override SievePropertyMapper MapProperties(SievePropertyMapper mapper) => 
+            mapper.ApplyConfigurationsFromAssembly(typeof(ModularConfigurationWithScanSieveProcessor).Assembly);
+    }
+}


### PR DESCRIPTION
Hi,

I saw there was an open discussion on having the concept of ["Mapping Profiles"](https://github.com/Biarity/Sieve/discussions/148) in Sieve.
In our project we are currently using lightweight extensions to the current fluent API, inspired by the EF Core EnityTypeConfigurations to split our mapping configurations in modules.

I think it would be a nice addition to the library that will not impact existing users.

The impact to the library is kept focused in the `ISieveConfiguration.cs`
I extended the mapping unit tests to run with 3 types of processors.
- "As is" mapping configuration in the processor
- Explicit mapper module configuration 
- Scanned module configuration.

`README.md` was also updated with possible usage scenarios

Kind regards,
Steven
