### PR TITLE
Fixed null-ref for case-(in)sensitive null-search

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,10 @@ More formally:
 * `pageSize` is the number of items returned per page 
 
 Notes:
-* You can use backslashes to escape commas and pipes within value fields
+* You can use backslashes to escape special characters and sequences:
+    * commas: `Title@=some\,title` makes a match with "some,title"
+    * pipes: `Title@=some\|title` makes a match with "some|title"
+    * null values: `Title@=\null` will search for items with title equal to "null" (not a missing value, but "null"-string literally)
 * You can have spaces anywhere except *within* `{Name}` or `{Operator}` fields
 * If you need to look at the data before applying pagination (eg. get total count), use the optional paramters on `Apply` to defer pagination (an [example](https://github.com/Biarity/Sieve/issues/34))
 * Here's a [good example on how to work with enumerables](https://github.com/Biarity/Sieve/issues/2)

--- a/Sieve/Models/FilterTerm.cs
+++ b/Sieve/Models/FilterTerm.cs
@@ -8,14 +8,15 @@ namespace Sieve.Models
     public class FilterTerm : IFilterTerm, IEquatable<FilterTerm>
     {
         private const string EscapedPipePattern = @"(?<!($|[^\\]|^)(\\\\)*?\\)\|";
+        private const string OperatorsRegEx = @"(!@=\*|!_=\*|!=\*|!@=|!_=|==\*|@=\*|_=\*|==|!=|>=|<=|>|<|@=|_=)";
+        private const string EscapeNegPatternForOper = @"(?<!\\)" + OperatorsRegEx;
+        private const string EscapePosPatternForOper = @"(?<=\\)" + OperatorsRegEx;
+
         private static readonly HashSet<string> _escapedSequences = new HashSet<string>
         {
             @"\|",
             @"\\"
         };
-        private const string OperatorsRegEx = @"(!@=\*|!_=\*|!=\*|!@=|!_=|==\*|@=\*|_=\*|==|!=|>=|<=|>|<|@=|_=)";
-        private const string EscapeNegPatternForOper = @"(?<!\\)" + OperatorsRegEx;
-        private const string EscapePosPatternForOper = @"(?<=\\)" + OperatorsRegEx;
 
         public string Filter
         {

--- a/SieveUnitTests/StringFilterNullTests.cs
+++ b/SieveUnitTests/StringFilterNullTests.cs
@@ -108,7 +108,9 @@ namespace SieveUnitTests
         [Theory]
         [InlineData(@"Author==\null", 100)]
         [InlineData(@"Author==*\null", 100)]
+        [InlineData(@"Author==*\NuLl", 100)]
         [InlineData(@"Author!=*\null", 0, 1, 2)]
+        [InlineData(@"Author!=*\NulL", 0, 1, 2)]
         [InlineData(@"Author!=\null", 0, 1, 2)]
         public void SingleFilter_Equals_NullStringEscaped(string filter, params int[] expectedIds)
         {

--- a/SieveUnitTests/StringFilterNullTests.cs
+++ b/SieveUnitTests/StringFilterNullTests.cs
@@ -38,7 +38,7 @@ namespace SieveUnitTests
                 {
                     Id = 2, 
                     DateCreated = DateTimeOffset.UtcNow, 
-                    Text = "Regular comment without n*ll.",
+                    Text = "Regular comment without n*ll",
                     Author = "Mouse",
                 },
                 new Comment
@@ -47,24 +47,28 @@ namespace SieveUnitTests
                     DateCreated = DateTimeOffset.UtcNow, 
                     Text = null,
                     Author = "null",
-                },
+                }
             }.AsQueryable();
         }
 
-        [Fact]
-        public void Filter_Equals_Null()
+        [Theory]
+        [InlineData("Text==null")]
+        [InlineData("Text==*null")]
+        public void Filter_Equals_Null(string filter)
         {
-            var model = new SieveModel {Filters = "Text==null"};
+            var model = new SieveModel {Filters = filter};
 
             var result = _processor.Apply(model, _comments);
 
             Assert.Equal(100, result.Single().Id);
         }
 
-        [Fact]
-        public void Filter_NotEquals_Null()
+        [Theory]
+        [InlineData("Text!=null")]
+        [InlineData("Text!=*null")]
+        public void Filter_NotEquals_Null(string filter)
         {
-            var model = new SieveModel {Filters = "Text!=null"};
+            var model = new SieveModel {Filters = filter};
 
             var result = _processor.Apply(model, _comments);
 
@@ -93,6 +97,20 @@ namespace SieveUnitTests
         [InlineData("Text|Author_=null", 1, 100)]
         [InlineData("Text|Author_=*null", 1, 100)]
         public void MultiFilter_Contains_NullString(string filter, params int[] expectedIds)
+        {
+            var model = new SieveModel {Filters = filter};
+
+            var result = _processor.Apply(model, _comments);
+
+            Assert.Equal(expectedIds, result.Select(p => p.Id));
+        }
+
+        [Theory]
+        [InlineData(@"Author==\null", 100)]
+        [InlineData(@"Author==*\null", 100)]
+        [InlineData(@"Author!=*\null", 0, 1, 2)]
+        [InlineData(@"Author!=\null", 0, 1, 2)]
+        public void SingleFilter_Equals_NullStringEscaped(string filter, params int[] expectedIds)
         {
             var model = new SieveModel {Filters = filter};
 


### PR DESCRIPTION
Added null-escaping sequence (to distinguish between prop==null (as null) and prop==\null (as string))