### PR TITLE
Disable the use of the nullable type expression for sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,8 @@ Then you can add the configuration:
         "DefaultPageSize": "int number: optional number to fallback to when no page argument is given. Set <=0 to disable paging if no pageSize is specified (default).",
         "MaxPageSize": "int number: maximum allowed page size. Set <=0 to make infinite (default)",
         "ThrowExceptions": "boolean: should Sieve throw exceptions instead of silently failing? Defaults to false",
-        "IgnoreNullsOnNotEqual": "boolean: ignore null values when filtering using is not equal operator? Default to true"
+        "IgnoreNullsOnNotEqual": "boolean: ignore null values when filtering using is not equal operator? Defaults to true",
+        "DisableNullableTypeExpressionForSorting": "boolean: disable the creation of nullable type expression for sorting. Some databases do not handle it (yet). Defaults to false"
     }
 }
 ```

--- a/Sieve/Extensions/OrderByDynamic.cs
+++ b/Sieve/Extensions/OrderByDynamic.cs
@@ -12,9 +12,10 @@ namespace Sieve.Extensions
             string fullPropertyName,
             PropertyInfo propertyInfo,
             bool desc,
-            bool useThenBy)
+            bool useThenBy, 
+            bool disableNullableTypeExpression = false)
         {
-            var lambda = GenerateLambdaWithSafeMemberAccess<TEntity>(fullPropertyName, propertyInfo);
+            var lambda = GenerateLambdaWithSafeMemberAccess<TEntity>(fullPropertyName, propertyInfo, disableNullableTypeExpression);
 
             var command = desc
                 ? (useThenBy ? "ThenByDescending" : "OrderByDescending")
@@ -33,7 +34,8 @@ namespace Sieve.Extensions
         private static Expression<Func<TEntity, object>> GenerateLambdaWithSafeMemberAccess<TEntity>
         (
             string fullPropertyName,
-            PropertyInfo propertyInfo
+            PropertyInfo propertyInfo,
+            bool disableNullableTypeExpression
         )
         {
             var parameter = Expression.Parameter(typeof(TEntity), "e");
@@ -52,7 +54,7 @@ namespace Sieve.Extensions
                     propertyValue = Expression.MakeMemberAccess(propertyValue, propertyInfo);
                 }
 
-                if (propertyValue.Type.IsNullable())
+                if (propertyValue.Type.IsNullable() && !disableNullableTypeExpression)
                 {
                     nullCheck = GenerateOrderNullCheckExpression(propertyValue, nullCheck);
                 }

--- a/Sieve/Models/SieveOptions.cs
+++ b/Sieve/Models/SieveOptions.cs
@@ -11,5 +11,7 @@
         public bool ThrowExceptions { get; set; } = false;
 
         public bool IgnoreNullsOnNotEqual { get; set; } = true;
+
+        public bool DisableSortNullableTypeExpression { get; set; } = false;
     }
 }

--- a/Sieve/Models/SieveOptions.cs
+++ b/Sieve/Models/SieveOptions.cs
@@ -12,6 +12,6 @@
 
         public bool IgnoreNullsOnNotEqual { get; set; } = true;
 
-        public bool DisableSortNullableTypeExpression { get; set; } = false;
+        public bool DisableNullableTypeExpressionForSorting { get; set; } = false;
     }
 }

--- a/Sieve/Services/SieveProcessor.cs
+++ b/Sieve/Services/SieveProcessor.cs
@@ -365,7 +365,7 @@ namespace Sieve.Services
 
                 if (property != null)
                 {
-                    result = result.OrderByDynamic(fullName, property, sortTerm.Descending, useThenBy, Options.Value.DisableSortNullableTypeExpression);
+                    result = result.OrderByDynamic(fullName, property, sortTerm.Descending, useThenBy, Options.Value.DisableNullableTypeExpressionForSorting);
                 }
                 else
                 {

--- a/Sieve/Services/SieveProcessor.cs
+++ b/Sieve/Services/SieveProcessor.cs
@@ -365,7 +365,7 @@ namespace Sieve.Services
 
                 if (property != null)
                 {
-                    result = result.OrderByDynamic(fullName, property, sortTerm.Descending, useThenBy);
+                    result = result.OrderByDynamic(fullName, property, sortTerm.Descending, useThenBy, Options.Value.DisableSortNullableTypeExpression);
                 }
                 else
                 {


### PR DESCRIPTION
MongoDB has issues with the expression created when sorting on nullable types.
So I created an option to disable it.

If there is anything I need to do to improve it please let us know