### PR TITLE
Add support to change the current CulutureInfo

### DIFF
--- a/Sieve/Models/SieveOptions.cs
+++ b/Sieve/Models/SieveOptions.cs
@@ -1,5 +1,3 @@
-﻿using System.Globalization;
-
 namespace Sieve.Models
 {
     public class SieveOptions
@@ -15,7 +13,7 @@ namespace Sieve.Models
         public bool IgnoreNullsOnNotEqual { get; set; } = true;
 
         public bool DisableNullableTypeExpressionForSorting { get; set; } = false;
-        
-        public CultureInfo CultureInfo { get; set; } = CultureInfo.CurrentCulture;
+      
+        public string CultureNameOfTypeConversion { get; set; } = "en";
     }
 }

--- a/Sieve/Models/SieveOptions.cs
+++ b/Sieve/Models/SieveOptions.cs
@@ -1,4 +1,6 @@
-﻿namespace Sieve.Models
+﻿using System.Globalization;
+
+namespace Sieve.Models
 {
     public class SieveOptions
     {
@@ -13,5 +15,7 @@
         public bool IgnoreNullsOnNotEqual { get; set; } = true;
 
         public bool DisableNullableTypeExpressionForSorting { get; set; } = false;
+        
+        public CultureInfo CultureInfo { get; set; } = CultureInfo.CurrentCulture;
     }
 }

--- a/Sieve/Services/SieveProcessor.cs
+++ b/Sieve/Services/SieveProcessor.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -122,6 +123,9 @@ namespace Sieve.Services
             object[] dataForCustomMethods = null, bool applyFiltering = true, bool applySorting = true,
             bool applyPagination = true)
         {
+            var currentCultureInfo = CultureInfo.CurrentCulture;
+            CultureInfo.CurrentCulture = Options.Value.CultureInfo;
+            
             var result = source;
 
             if (model == null)
@@ -161,6 +165,10 @@ namespace Sieve.Services
                 }
 
                 throw new SieveException(ex.Message, ex);
+            }
+            finally
+            {
+                CultureInfo.CurrentCulture = currentCultureInfo;
             }
         }
 

--- a/SieveUnitTests/Abstractions/Entity/IPost.cs
+++ b/SieveUnitTests/Abstractions/Entity/IPost.cs
@@ -9,6 +9,8 @@ namespace SieveUnitTests.Abstractions.Entity
         string Title { get; set; }
         [Sieve(CanFilter = true, CanSort = true)]
         int LikeCount { get; set; }
+        [Sieve(CanFilter = true)]
+        float MeanRating { get; set; }
         [Sieve(CanFilter = true, CanSort = true)]
         int CommentCount { get; set; }
         [Sieve(CanFilter = true, CanSort = true)]

--- a/SieveUnitTests/Entities/Post.cs
+++ b/SieveUnitTests/Entities/Post.cs
@@ -12,6 +12,9 @@ namespace SieveUnitTests.Entities
 
         [Sieve(CanFilter = true, CanSort = true)]
         public int LikeCount { get; set; } = new Random().Next(0, 1000);
+        
+        [Sieve(CanFilter = true)]
+        public float MeanRating { get; set; } = 0.0f;
 
         [Sieve(CanFilter = true, CanSort = true)]
         public int CommentCount { get; set; } = new Random().Next(0, 1000);

--- a/SieveUnitTests/Entities/Post.cs
+++ b/SieveUnitTests/Entities/Post.cs
@@ -14,7 +14,7 @@ namespace SieveUnitTests.Entities
         public int LikeCount { get; set; } = new Random().Next(0, 1000);
         
         [Sieve(CanFilter = true)]
-        public float MeanRating { get; set; } = 0.0f;
+        public float MeanRating { get; set; }
 
         [Sieve(CanFilter = true, CanSort = true)]
         public int CommentCount { get; set; } = new Random().Next(0, 1000);

--- a/SieveUnitTests/General.cs
+++ b/SieveUnitTests/General.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using Sieve.Exceptions;
 using Sieve.Models;
@@ -854,8 +853,7 @@ namespace SieveUnitTests
             Assert.Equal(1, resultCount);
         }
         
-        
-         [Theory]
+        [Theory]
         [InlineData("en-US", "1.2")]
         [InlineData("de-DE", @"1\,2")]
         public void ParseFloatsWithChangedCultureInfo_Works(string culture, string value)
@@ -877,7 +875,7 @@ namespace SieveUnitTests
             }.AsQueryable();
 
             var optionsAccessor = new SieveOptionsAccessor();
-            optionsAccessor.Value.CultureInfo = new CultureInfo(culture, false);
+            optionsAccessor.Value.CultureNameOfTypeConversion = culture;
 
             var processor = new ApplicationSieveProcessor(optionsAccessor,
                 new SieveCustomSortMethods(),
@@ -893,8 +891,8 @@ namespace SieveUnitTests
         }
 
         [Theory]
-        [InlineData("en-US", @"1\,2")]
-        [InlineData("de-DE", "1.2")]
+        [InlineData("en", @"1\,2")]
+        [InlineData("de", "1.2")]
         public void ParseFloatsWithChangedCultureInfo_Fails(string culture, string value)
         {
             // ARRANGE
@@ -914,7 +912,7 @@ namespace SieveUnitTests
             }.AsQueryable();
 
             var optionsAccessor = new SieveOptionsAccessor();
-            optionsAccessor.Value.CultureInfo = new CultureInfo(culture, false);
+            optionsAccessor.Value.CultureNameOfTypeConversion = culture;
 
             var processor = new ApplicationSieveProcessor(optionsAccessor,
                 new SieveCustomSortMethods(),


### PR DESCRIPTION
When the value of a filter like "MeanRating==1.2" is parsed/converted and the current CultureInfo is e.g. de-DE, then the conversion fails with an exception, because 1.2 is not a valid format in culture.

So it would be good, to let the developer decide which CultureInfo should be used by Sieve.

Therefore this pull request added a CultureInfo property to the SieveOptions, that is used in the Apply method of the SieveProcessor to change the current culture during processing.