### PR TITLE
feat: Implement support for mapping PropertyInfo directly

### DIFF
--- a/Sieve/Services/SievePropertyMapper.cs
+++ b/Sieve/Services/SievePropertyMapper.cs
@@ -22,6 +22,16 @@ namespace Sieve.Services
             return new PropertyFluentApi<TEntity>(this, expression);
         }
 
+        public PropertyFluentApi<TEntity> Property<TEntity>(PropertyInfo propertyInfo)
+        {
+            if (!_map.ContainsKey(typeof(TEntity)))
+            {
+                _map.Add(typeof(TEntity), new List<KeyValuePair<PropertyInfo, ISievePropertyMetadata>>());
+            }
+
+            return new PropertyFluentApi<TEntity>(this, propertyInfo);
+        }
+
         public class PropertyFluentApi<TEntity>
         {
             private readonly SievePropertyMapper _sievePropertyMapper;
@@ -31,6 +41,15 @@ namespace Sieve.Services
             {
                 _sievePropertyMapper = sievePropertyMapper;
                 (_fullName, _property) = GetPropertyInfo(expression);
+                _name = _fullName;
+                _canFilter = false;
+                _canSort = false;
+            }
+
+            public PropertyFluentApi(SievePropertyMapper sievePropertyMapper, PropertyInfo propertyInfo)
+            {
+                _sievePropertyMapper = sievePropertyMapper;
+                (_fullName, _property) = (propertyInfo.Name, propertyInfo);
                 _name = _fullName;
                 _canFilter = false;
                 _canSort = false;

--- a/SieveUnitTests/Abstractions/Entity/IPost.cs
+++ b/SieveUnitTests/Abstractions/Entity/IPost.cs
@@ -17,6 +17,7 @@ namespace SieveUnitTests.Abstractions.Entity
         bool IsDraft { get; set; }
         string ThisHasNoAttribute { get; set; }
         string ThisHasNoAttributeButIsAccessible { get; set; }
+        string ThisHasNoAttributeButIsAccessible2 { get; set; }
         int OnlySortableViaFluentApi { get; set; }
         Comment TopComment { get; set; }
         Comment FeaturedComment { get; set; }

--- a/SieveUnitTests/Abstractions/Entity/SieveConfigurationForIPost.cs
+++ b/SieveUnitTests/Abstractions/Entity/SieveConfigurationForIPost.cs
@@ -1,4 +1,5 @@
 ﻿using Sieve.Services;
+using SieveUnitTests.Entities;
 
 namespace SieveUnitTests.Abstractions.Entity
 {
@@ -10,7 +11,12 @@ namespace SieveUnitTests.Abstractions.Entity
                 .CanSort()
                 .CanFilter()
                 .HasName("shortname");
-            
+
+            mapper.Property<IPost>(typeof(IPost).GetProperty(nameof(IPost.ThisHasNoAttributeButIsAccessible2)))
+                .CanSort()
+                .CanFilter()
+                .HasName("shortname2");
+
             mapper.Property<IPost>(p => p.TopComment.Text)
                 .CanFilter();
 

--- a/SieveUnitTests/Entities/Post.cs
+++ b/SieveUnitTests/Entities/Post.cs
@@ -26,6 +26,8 @@ namespace SieveUnitTests.Entities
 
         public string ThisHasNoAttributeButIsAccessible { get; set; }
 
+        public string ThisHasNoAttributeButIsAccessible2 { get; set; }
+
         public int OnlySortableViaFluentApi { get; set; }
 
         public Comment TopComment { get; set; }

--- a/SieveUnitTests/Entities/SieveConfigurationForPost.cs
+++ b/SieveUnitTests/Entities/SieveConfigurationForPost.cs
@@ -11,6 +11,11 @@ namespace SieveUnitTests.Entities
                 .CanFilter()
                 .HasName("shortname");
 
+            mapper.Property<Post>(typeof(Post).GetProperty(nameof(Post.ThisHasNoAttributeButIsAccessible2)))
+                .CanSort()
+                .CanFilter()
+                .HasName("shortname2");
+
             mapper.Property<Post>(p => p.TopComment.Text)
                 .CanFilter();
 

--- a/SieveUnitTests/Mapper.cs
+++ b/SieveUnitTests/Mapper.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using Sieve.Exceptions;
 using Sieve.Models;
@@ -21,6 +21,7 @@ namespace SieveUnitTests
                 {
                     Id = 1,
                     ThisHasNoAttributeButIsAccessible = "A",
+                    ThisHasNoAttributeButIsAccessible2 = "A",
                     ThisHasNoAttribute = "A",
                     OnlySortableViaFluentApi = 100
                 },
@@ -28,6 +29,7 @@ namespace SieveUnitTests
                 {
                     Id = 2,
                     ThisHasNoAttributeButIsAccessible = "B",
+                    ThisHasNoAttributeButIsAccessible2 = "B",
                     ThisHasNoAttribute = "B",
                     OnlySortableViaFluentApi = 50
                 },
@@ -35,6 +37,7 @@ namespace SieveUnitTests
                 {
                     Id = 3,
                     ThisHasNoAttributeButIsAccessible = "C",
+                    ThisHasNoAttributeButIsAccessible2 = "C",
                     ThisHasNoAttribute = "C",
                     OnlySortableViaFluentApi = 0
                 },
@@ -77,6 +80,22 @@ namespace SieveUnitTests
             var result = processor.Apply(model, _posts);
 
             Assert.Equal("A", result.First().ThisHasNoAttributeButIsAccessible);
+
+            Assert.True(result.Count() == 1);
+        }
+
+        [Theory]
+        [MemberData(nameof(GetProcessors))]
+        public void MapperWorksWithPropertyInfo(ISieveProcessor processor)
+        {
+            var model = new SieveModel
+            {
+                Filters = "shortname2@=A",
+            };
+
+            var result = processor.Apply(model, _posts);
+
+            Assert.Equal("A", result.First().ThisHasNoAttributeButIsAccessible2);
 
             Assert.True(result.Count() == 1);
         }

--- a/SieveUnitTests/Services/ApplicationSieveProcessor.cs
+++ b/SieveUnitTests/Services/ApplicationSieveProcessor.cs
@@ -23,6 +23,11 @@ namespace SieveUnitTests.Services
                 .CanFilter()
                 .HasName("shortname");
 
+            mapper.Property<Post>(typeof(Post).GetProperty(nameof(Post.ThisHasNoAttributeButIsAccessible2)))
+                .CanSort()
+                .CanFilter()
+                .HasName("shortname2");
+
             mapper.Property<Post>(p => p.TopComment.Text)
                 .CanFilter();
 
@@ -50,6 +55,11 @@ namespace SieveUnitTests.Services
                 .CanSort()
                 .CanFilter()
                 .HasName("shortname");
+
+            mapper.Property<IPost>(typeof(IPost).GetProperty(nameof(IPost.ThisHasNoAttributeButIsAccessible2)))
+                .CanSort()
+                .CanFilter()
+                .HasName("shortname2");
 
             mapper.Property<IPost>(p => p.TopComment.Text)
                 .CanFilter();


### PR DESCRIPTION
This change implements support to **map** directly **PropertyInfo**. There are use cases when using attributes is not possible. For example when a project is forced to use _Entity Framework Core - Database First with scaffolding_, this would be a big time saver. 

Example: Map all properties of a class with a single line:
```
typeof(Post).GetProperties().ToList().ForEach(p => mapper.Property<Post>(p).CanSort().CanFilter());
```

