### PR TITLE
docs: Fix dead sample link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ It is recommended that you write exception-handling middleware to globally handl
 
 
 ### Example project
-You can find an example project incorporating most Sieve concepts in [SieveTests](https://github.com/Biarity/Sieve/tree/master/SieveTests).
+You can find an example project incorporating most Sieve concepts in [Sieve.Sample](https://github.com/Biarity/Sieve/tree/master/Sieve.Sample).
 
 ## Fluent API
 To use the Fluent API instead of attributes in marking properties, setup an alternative `SieveProcessor` that overrides `MapProperties`. For [example](https://github.com/Biarity/Sieve/blob/master/Sieve.Sample/Services/ApplicationSieveProcessor.cs):


### PR DESCRIPTION
Hello,

As outlined in #200, there's a dead link in the `README.md` file. Since there aren't any contributing guidelines, I figure that you merge into `master`.

Fixes #200 